### PR TITLE
Proofing/Refining Command Reference Page (Through Anchor Commands)

### DIFF
--- a/src/routes/core/fundamentals/commands-usage/+page.md
+++ b/src/routes/core/fundamentals/commands-usage/+page.md
@@ -73,6 +73,10 @@ Many commands in Multiverse use flags, these can be one or two dashes. Two dash 
 
 There are two flags that are frequently used: `--filter` and `--page`. These are used for filtering and selecting the page respectively of a paginated command (a command that returns multiple pages). Note that pagination does not apply when running from the console. 
 
+### Optional vs. Required Params
+
+Items inside square braces (`[]`) are **OPTIONAL** where items inside (`<>`) are **REQUIRED**.
+
 ### Simple command example
 
 This is a simple command, which can be quickly broken down into parts:

--- a/src/routes/core/fundamentals/commands-usage/+page.md
+++ b/src/routes/core/fundamentals/commands-usage/+page.md
@@ -11,10 +11,11 @@ For older mv4 versions, check our github wiki: https://github.com/Multiverse/Mul
 
 :::
 
-If you're looking for the [Multiverse-Portals](/portals/fundamentals/commands-usage), [Multiverse-NetherPortals](/netherportals/fundamentals/commands-usage) or [Multiverse-Inventories](/inventories/fundamentals/commands-usage) Command References, click the links!
-
-**Looking for the permissions?**  
-[Click here to go the Big List O' Permissions!](/core/reference/permissions-list)
+This page is a reference for Core Multiverse commands. For other command reference pages, see below:
+* [Multiverse-Portals](/portals/fundamentals/commands-usage) 
+* [Multiverse-NetherPortals](/netherportals/fundamentals/commands-usage) 
+* [Multiverse-Inventories](/inventories/fundamentals/commands-usage)
+* [Permissions List](/core/reference/permissions-list)
 
 ## Index
 
@@ -62,38 +63,44 @@ If you're looking for the [Multiverse-Portals](/portals/fundamentals/commands-us
 
 ## Introduction
 
-In Multiverse, we have included a handy new in-game help system. To access this help, simply type `/mv`. In order to properly read this command reference, we'll walk through reading the "usage" of a command.
+There is an in-game help system! To access this, type `/mv`. This section will break down how to read commands.
 
 ### Command Case
 
-Whenever reading this wiki or the in-game [`/mv`](#help) help, you should remember that items in **ALL CAPS** should be replaced with a variable. Items in lowercase should be typed exactly how they appear.
+Whenever reading this wiki or the in-game [`/mv`](#help) help, items in **ALL CAPS** should be replaced with a variable. Items in lowercase should be typed exactly how they appear.
 
-### Optional vs. Required Params
+### Parameters and Flags
 
-Items inside square braces (`[]`) are **OPTIONAL** where items inside (`<>`) are **REQUIRED**
+Using a basic command is frequently not enough for what you may be trying to do. Parameters and flags are added to the ends of commands to provide additional specific instructions. Parameters can be required or optional - when a command example is written out, items inside square braces (`[]`) are **OPTIONAL** where items inside (`<>`) are **REQUIRED**.
+
+Many commands in Multiverse use flags, these can be one or two dashes. Two dash flags are whole words (e.g: `--filter`) and one dash flags are shorthand versions of the same thing (e.g: `-f`). Flags are usually optional, allowing for specifying a command further (e.g. adding a generation seed to a command to generate a new world). Flags frequently have optional or required parameters of their own.
+
+There are two flags that are frequently used: `--filter` and `--page`. These are used for filtering and selecting the page respectively of a paginated command (a command that returns multiple pages). Note that pagination does not apply when running from the console. 
 
 ### Simple command example
 
-Let's look at a simple one first:
+This is a simple command, which can be quickly broken down into parts:
 
-[`/mv info [world]`](#Information-Command)
+[`/mv info [WORLD]`](#Information-Command)
 
-This means that this command has one optional parameter, meaning you could type [`/mv info`](#Information-Command) **or** [`/mv info world`](#Information-Command). Obviously, the command will do different things with or without its params. You can tell what those effects are by reading this wiki.
+* The first part of this command `/mv` specifies the Multiverse plugin.
+* The second part of this command `info` is the [information command](#Information-Command), used to get information about a world.
+* The third part of this command `[WORLD]` is an OPTIONAL parameter, meaning you could type [`/mv info`](#Information-Command) **or** [`/mv info world`](#Information-Command). The command may have different effects with or without its params. For example, `/mv info world_the_end` will provide information about The End world. If you are currently standing in The End, `/mv info` will provide that info without needing to specify the param.
 
 ### Complex command example
 
 Let's look at the most complex example:  
 _NOTE: This is the most complex command in MV2 and in order to use it correctly, please refer to the [Create Command](#Create-Command)._
 
-[`/mv create <name> <environment> [--seed <seed> --generator <generator[:id]> --world-type <worldtype> --adjust-spawn --no-structures --biome <biome>]`](#Create-Command)
+[`/mv create <NAME> <ENVIRONMENT> [--seed <SEED> --generator <generator[ID]> --world-type <WORLDTYPE> --adjust-spawn --no-structures --biome <BIOME>]`](#Create-Command)
 
-At first, you will notice that there are 2 required params, **name**, and **environment**. Then you will see the flags afterward. If you want to use a [seed](/core/fundamentals/world-properties#Seed) you must add `--seed gargamel` to the command string. If you want a [generator](/core/fundamentals/world-properties#Generators) the same principle applies: `--generator BukkitFullOfMoon`. The order of flags does _not_ matter. Full examples of this command are located at the [Create Command reference](#Create-Command).
+* `/mv` specifies the Multiverse plugin.
+* `create` is the [create command](#Create-Command), used to create a new world.
+* `<NAME>` is a REQUIRED parameter. You must provide a name for the world.
+* `<ENVIRONMENT>` is a REQUIRED parameter. You must specify whether it is a normal, nether, or the_end world.
+* `[--seed <SEED> ... --biome <BIOME>]` is an OPTIONAL set of flags that can be used to modify the base commmand.
 
-### Flags
-
-Many commands in Multiverse use flags, these can be one or two dashes. Two dash flags are whole words (e.g: `--filter`) and one dash flags are shorthand versions of the same thing (e.g: `-f`).
-
-There are two flags that you will come across quite a lot: `--filter` and `--page`. These are used for filtering and selecting the page respectively of a paginated command. FYI, pagination does not apply when running from the console. 
+For example, if you want to use the "gargamel" [seed](/core/fundamentals/world-properties#Seed) you must add `--seed gargamel` to the command string. If you want a [generator](/core/fundamentals/world-properties#Generators) like "BukkitFullOfMoon", you must add `--generator BukkitFullOfMoon`. The order of flags does _not_ matter, and all of them are optional. Full examples of this command are located at the [Create Command reference](#Create-Command). 
 
 [↑ Back to Top ↑](#top)
 
@@ -101,21 +108,24 @@ There are two flags that you will come across quite a lot: `--filter` and `--pag
 
 ### Description
 
-Anchors should be used if you have a place you want to go frequently. Using the `/mv anchor set <name>` command to first create an anchor, you can then use it in any command that takes a destination. 
+Any location you frequently plan to teleport to or point to as a destination can be turned into an anchor. First use the `/mv anchor set <NAME>` command to create an anchor, then use the new anchor name in any command that takes a destination. 
 
 ### Usage
 
 ```java
-/mv anchor set <name> [location]
+/mv anchor set <NAME> [LOCATION]
 ```
 
-- `<name>`: The name of the anchor. If the anchor already exists, it location will be overwritten.
-- `[location]`: The location of the anchor. Must be specified if running from the console.
+- `<NAME>`: The name of the anchor. If the anchor already exists, it location will be overwritten.
+- `[LOCATION]`: The location of the anchor. Must be specified if running from the console.
 
 ### Examples
 
 - `/mv anchor set myanchor` - Creates the anchor with the name `myanchor` at your current location. 
 - `/mv anchor set coolanchor cool:1,2,3:10:12` - Creates the anchor with the name `coolanchor` at location world `cool`, x: 1, y: 2, z: 3, pitch: 10, yaw: 12.
+
+Example of teleporting to an anchor:
+- `/mvtp a:myanchor` - Teleports the user to the anchor named `myanchor`. For more teleport commands, see [Teleport Command](#Teleport-Command).
 
 ### Permission
 
@@ -129,16 +139,16 @@ For teleport permission of anchors `/mvtp a:<anchorname>`, see [Anchor Destinati
 
 ### Description
 
-List all anchors and its corresponding locations.
+List all anchors and their corresponding locations.
 
 ### Usage
 
 ```java
-/mv anchor list [--page <page> --filter <filter>]
+/mv anchor list [--page <PAGE> --filter <FILTER>]
 ```
 
-- `--page <page>`: The page of the list to show. Defaults to 1.
-- `--filter <filter>`: The filter to apply to the list.
+- `--page <PAGE>`: The page of the list to show. Defaults to 1.
+- `--filter <FILTER>`: The filter to apply to the list.
 
 ### Permission
 
@@ -155,10 +165,10 @@ Deletes an existing anchor. Note there is no way to undo this action.
 ### Usage
 
 ```java
-/mv anchor delete <anchorname>
+/mv anchor delete <ANCHORNAME>
 ```
 
-- `<anchorname>`: The name of the anchor to delete. Command will fail if anchor does not exist.
+- `<ANCHORNAME>`: The name of the anchor to delete. Command will fail if anchor does not exist.
 
 ### Examples
 

--- a/src/routes/core/fundamentals/commands-usage/+page.md
+++ b/src/routes/core/fundamentals/commands-usage/+page.md
@@ -63,11 +63,7 @@ This page is a reference for Core Multiverse commands. For other command referen
 
 ## Introduction
 
-There is an in-game help system! To access this, type `/mv`. This section will break down how to read commands.
-
-### Command Case
-
-Whenever reading this wiki or the in-game [`/mv`](#help) help, items in **ALL CAPS** should be replaced with a variable. Items in lowercase should be typed exactly how they appear.
+There is an in-game help system! To access this, type `/mv help`. This section will break down how to read commands.
 
 ### Parameters and Flags
 
@@ -81,24 +77,24 @@ There are two flags that are frequently used: `--filter` and `--page`. These are
 
 This is a simple command, which can be quickly broken down into parts:
 
-[`/mv info [WORLD]`](#Information-Command)
+[`/mv info [world]`](#Information-Command)
 
 * The first part of this command `/mv` specifies the Multiverse plugin.
 * The second part of this command `info` is the [information command](#Information-Command), used to get information about a world.
-* The third part of this command `[WORLD]` is an OPTIONAL parameter, meaning you could type [`/mv info`](#Information-Command) **or** [`/mv info world`](#Information-Command). The command may have different effects with or without its params. For example, `/mv info world_the_end` will provide information about The End world. If you are currently standing in The End, `/mv info` will provide that info without needing to specify the param.
+* The third part of this command `[world]` is an OPTIONAL parameter, meaning you could type [`/mv info`](#Information-Command) **or** [`/mv info world`](#Information-Command). The command may have different effects with or without its params. For example, `/mv info world_the_end` will provide information about The End world. If you are currently standing in The End, `/mv info` will provide that info without needing to specify the param.
 
 ### Complex command example
 
 Let's look at the most complex example:  
 _NOTE: This is the most complex command in MV2 and in order to use it correctly, please refer to the [Create Command](#Create-Command)._
 
-[`/mv create <NAME> <ENVIRONMENT> [--seed <SEED> --generator <generator[ID]> --world-type <WORLDTYPE> --adjust-spawn --no-structures --biome <BIOME>]`](#Create-Command)
+[`/mv create <name> <environment> [--seed <seed> --generator <generator[:id]> --world-type <worldtype> --adjust-spawn --no-structures --biome <biome>]`](#Create-Command)
 
 * `/mv` specifies the Multiverse plugin.
 * `create` is the [create command](#Create-Command), used to create a new world.
-* `<NAME>` is a REQUIRED parameter. You must provide a name for the world.
-* `<ENVIRONMENT>` is a REQUIRED parameter. You must specify whether it is a normal, nether, or the_end world.
-* `[--seed <SEED> ... --biome <BIOME>]` is an OPTIONAL set of flags that can be used to modify the base commmand.
+* `<name>` is a **REQUIRED** parameter. You must provide a name for the world.
+* `<environment>` is a REQUIRED parameter. You must specify whether it is a `normal`, `nether`, or `the_end` world.
+* `[--seed <seed> ... --biome <biome>]` is an OPTIONAL set of flags that can be used to modify the base commmand.
 
 For example, if you want to use the "gargamel" [seed](/core/fundamentals/world-properties#Seed) you must add `--seed gargamel` to the command string. If you want a [generator](/core/fundamentals/world-properties#Generators) like "BukkitFullOfMoon", you must add `--generator BukkitFullOfMoon`. The order of flags does _not_ matter, and all of them are optional. Full examples of this command are located at the [Create Command reference](#Create-Command). 
 
@@ -108,16 +104,16 @@ For example, if you want to use the "gargamel" [seed](/core/fundamentals/world-p
 
 ### Description
 
-Any location you frequently plan to teleport to or point to as a destination can be turned into an anchor. First use the `/mv anchor set <NAME>` command to create an anchor, then use the new anchor name in any command that takes a destination. 
+Any location you frequently plan to teleport to or point to as a destination can be turned into an anchor. First use the `/mv anchor set <name>` command to create an anchor, then use the new anchor name in any command that takes a destination. 
 
 ### Usage
 
 ```java
-/mv anchor set <NAME> [LOCATION]
+/mv anchor set <name> [location]
 ```
 
-- `<NAME>`: The name of the anchor. If the anchor already exists, it location will be overwritten.
-- `[LOCATION]`: The location of the anchor. Must be specified if running from the console.
+- `<name>`: The name of the anchor. If the anchor already exists, it location will be overwritten.
+- `[location]`: The location of the anchor. Must be specified if running from the console.
 
 ### Examples
 
@@ -144,11 +140,11 @@ List all anchors and their corresponding locations.
 ### Usage
 
 ```java
-/mv anchor list [--page <PAGE> --filter <FILTER>]
+/mv anchor list [--page <page> --filter <filter>]
 ```
 
-- `--page <PAGE>`: The page of the list to show. Defaults to 1.
-- `--filter <FILTER>`: The filter to apply to the list.
+- `--page <page>`: The page of the list to show. Defaults to 1.
+- `--filter <filter>`: The filter to apply to the list.
 
 ### Permission
 
@@ -165,10 +161,10 @@ Deletes an existing anchor. Note there is no way to undo this action.
 ### Usage
 
 ```java
-/mv anchor delete <ANCHORNAME>
+/mv anchor delete <anchorname>
 ```
 
-- `<ANCHORNAME>`: The name of the anchor to delete. Command will fail if anchor does not exist.
+- `<anchorname>`: The name of the anchor to delete. Command will fail if anchor does not exist.
 
 ### Examples
 


### PR DESCRIPTION
I took a stab at some proofing and standardization for an hour in the first parts, including trying to clarify how to read commands. I noticed (and did not fix throughout) that early on it specifies that lowercase parts need to be exactly the same while ALL CAPS parts should be changed, but the commands themselves did not reflect this. I adjusted that in the sections that I reviewed, but that should be standardized one way or another.