### PR TITLE
Add /mv version command changes

### DIFF
--- a/src/routes/mv5/welcome/command-changes/+page.md
+++ b/src/routes/mv5/welcome/command-changes/+page.md
@@ -14,3 +14,4 @@ title: "Command Changes"
 | `/mv purge [world/all] <all/animals/monsters/mobname>` | `/mv purge-all-entities <spawn-categories>` |
 | `/mv env` | _removed_ |
 | `/mv silent` | _removed_ |
+| `/mv version -p` | `/mv dumps` |


### PR DESCRIPTION
`/mv version -p` changed to `/mv dumps` by the looks of it, which isn't listed in the command changes page.
I've added that to the page.