### PR TITLE
Fix small Typo

### DIFF
--- a/src/routes/core/developers/developer-api-starter/+page.md
+++ b/src/routes/core/developers/developer-api-starter/+page.md
@@ -15,7 +15,7 @@ The multiverse's artifacts are published on our own maven repository: https://re
 ```xml
 <repositories>
     <repository>
-        <id>onarandombodx</id>
+        <id>onarandombox</id>
         <url>https://repo.onarandombox.com/content/groups/public/</url>
     </repository>
 </repositories>


### PR DESCRIPTION
this entire PR goes around a small typo under [Developer-API-Starter](https://mvplugins.org/core/developers/developer-api-starter/): 
<img width="577" height="142" alt="grafik" src="https://github.com/user-attachments/assets/717ff882-a0da-4ce5-b183-3157ef138eeb" />

i know, a really important pr. It will change the entire world of documentation