### PR TITLE
Specify in Module Pages that version numbers do not need to match

### DIFF
--- a/src/routes/inventories/+page.md
+++ b/src/routes/inventories/+page.md
@@ -6,7 +6,7 @@ For an English language video tutorial [check here](https://www.youtube.com/watc
 
 ## Prerequisites
 There are a few things to verify before installing [Multiverse-Inventories](https://dev.bukkit.org/projects/multiverse-inventories).
-* When running other Multiverse modules (such as Inventories, ensure it's the same version as [Multiverse-Core](https://dev.bukkit.org/projects/multiverse-core). For example, if Multiverse-Inventories is 4.0.0, Multiverse-Core should be 4.0.0.
+* When running other Multiverse modules (such as Inventories), get the latest version of all modules - the slight difference in version number does not matter as long as its all v5.
 * You must have [Multiverse-Core](https://dev.bukkit.org/projects/multiverse-core) before having Multiverse-Inventories.
 
 ## Step 1

--- a/src/routes/portals/+page.md
+++ b/src/routes/portals/+page.md
@@ -6,7 +6,8 @@ For an English language video tutorial [check here](https://www.youtube.com/watc
 
 ## Prerequisites
 There are a few things to verify before installing [Multiverse-Portals](https://dev.bukkit.org/projects/multiverse-portals).
-* When running other Multiverse modules (such as Portals, ensure it's the same version as [Multiverse-Core](https://dev.bukkit.org/projects/multiverse-core). For example, if Multiverse-Portals is 4.0.0, Multiverse-Core should be 4.0.0.
+* When running other Multiverse modules (such as Portals), get the latest version of all modules - the slight difference in version number does not matter as long as its all v5.
+
 * You must have [Multiverse-Core](https://dev.bukkit.org/projects/multiverse-core) before having Multiverse-Portals.
 
 ## Step 1

--- a/src/routes/signportals/+page.md
+++ b/src/routes/signportals/+page.md
@@ -4,7 +4,7 @@ title: "Installation"
 
 ## Prerequisites
 There are a few things to verify before installing [Multiverse-SignPortals](https://dev.bukkit.org/projects/multiverse-signportals).
-* When running other Multiverse modules (such as SignPortals, ensure it's the same version as [Multiverse-Core](https://dev.bukkit.org/projects/multiverse-core). For example, if Multiverse-SignPortals is 4.0.0, Multiverse-Core should be 4.0.0.
+* When running other Multiverse modules (such as SignPortals), get the latest version of all modules - the slight difference in version number does not matter as long as its all v5.
 * You must have [Multiverse-Core](https://dev.bukkit.org/projects/multiverse-core) before having Multiverse-SignPortals.
 
 ## Step 1


### PR DESCRIPTION
Within inventories, portals and signportals pages, replace the previous text about version numbers matching with Core to "get the latest version of all modules - the slight difference in version number does not matter as long as its all v5." 